### PR TITLE
[jahir] malloc compile warning and error handling fixes

### DIFF
--- a/sml/src/sml_value.c
+++ b/sml/src/sml_value.c
@@ -83,9 +83,7 @@ void sml_value_write(sml_value *value, sml_buffer *buf) {
 }
 
 sml_value *sml_value_init() {
-	sml_value *value = (sml_value *) malloc(sizeof(sml_value));
-	memset(value, 0, sizeof(value));
-
+	sml_value *value = calloc(1, sizeof(sml_value));
 	return value;
 }
 

--- a/sml/src/sml_value.c
+++ b/sml/src/sml_value.c
@@ -30,6 +30,9 @@ sml_value *sml_value_parse(sml_buffer *buf) {
 	unsigned char byte = sml_buf_get_current_byte(buf);
 
 	sml_value *value = sml_value_init();
+	if (value == NULL) {
+		return 0;
+	}
 	value->type = type;
 
 	switch (type) {


### PR DESCRIPTION
"fixed a compile warning and added a check for malloc() failures

the call to sml_value_init() should probably moved upwards, before sml_buf_get_next_type(), but I don't know if this will make anything better."

https://github.com/dailab/libsml/pull/7