### PR TITLE
[peterevertz] Fix for different timestamp sent by some meters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,6 @@ clean :
 	@$(MAKE) -C examples clean
 	@$(MAKE) -C test clean
 
+.PHONY: install
+install:
+	@$(MAKE) -C sml install

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -4,7 +4,7 @@ OBJS = sml_server.o
 LIBSML = ../sml/lib/libsml.a
 
 ifeq ($(UNAME), Linux)
-LIBS = -luuid
+LIBS = -luuid -lm
 endif
 
 sml_server : $(OBJS) $(LIBSML)

--- a/sml/Makefile
+++ b/sml/Makefile
@@ -67,3 +67,7 @@ clean:
 	@rm -f src/*.o
 	@rm -f $(DYN_LIB) $(OBJ_LIB) $(ST_LIB)
 
+install:
+	@cp lib/libsml.* /usr/lib
+	@cp -r include/sml /usr/include
+	@cp ../sml.pc /usr/lib/pkgconfig

--- a/sml/src/sml_time.c
+++ b/sml/src/sml_time.c
@@ -48,8 +48,24 @@ sml_time *sml_time_parse(sml_buffer *buf) {
 	tme->tag = sml_u8_parse(buf);
 	if (sml_buf_has_errors(buf)) goto error;
 
-	tme->data.timestamp = sml_u32_parse(buf);
-	if (sml_buf_has_errors(buf)) goto error;
+	int type=sml_buf_get_next_type(buf);
+	switch(type) {
+	case SML_TYPE_UNSIGNED:
+		tme->data.timestamp = sml_u32_parse(buf);
+		if (sml_buf_has_errors(buf)) goto error;
+		break;
+	case SML_TYPE_LIST:
+	{
+		int len=sml_buf_get_next_length(buf);
+		u32 *t1=sml_u32_parse(buf);
+		i16 *t2=sml_i16_parse(buf);
+		i16 *t3=sml_i16_parse(buf);
+		printf("sml_time as list[3]: ignoring value[0]=%u value[1]=%d value[2]=%d\n", *t1,*t2,*t3);
+	}
+		break;
+	default:
+		goto error;
+	}
 
 	return tme;
 


### PR DESCRIPTION
"some meters (FROETEC Multiflex ZG22) giving not one uint32 as timestamp, but a list of 3 values.
Ignoring these values, so that parsing did not fail.

Added a simple "make install"
Add some code to the example programm: can read a file, and give some more verbose output."

https://github.com/dailab/libsml/pull/6
