### PR TITLE
fix warnings

### DIFF
--- a/examples/sml_server.c
+++ b/examples/sml_server.c
@@ -76,7 +76,7 @@ void transport_receiver(unsigned char *buffer, size_t buffer_len) {
 	sml_file_free(file);
 }
 
-int main(int argc, char **argv) {
+int main(void) {
 	// this example assumes that a EDL21 meter sending SML messages via a
 	// serial device. Adjust as needed.
 	char *device = "/dev/cu.usbserial";

--- a/sml/src/sml_number.c
+++ b/sml/src/sml_number.c
@@ -27,7 +27,7 @@
 int sml_number_endian();
 void sml_number_byte_swap(unsigned char *bytes, int bytes_len);
 
-void *sml_number_init(u64 number, unsigned char type, int size) {
+void *sml_number_init(u64 number, unsigned char type __attribute__ ((unused)), int size) {
 	
 	unsigned char* bytes = (unsigned char*)&number;
 


### PR DESCRIPTION
- https://github.com/volkszaehler/libsml/issues/9#issuecomment-69315091
- https://github.com/volkszaehler/libsml/issues/10

- marks type parameter as unused.
- removes argc/argv from example program.