### PR TITLE
prevent buffer overwrite in sml_transport_read

### DIFF
--- a/sml/src/sml_transport.c
+++ b/sml/src/sml_transport.c
@@ -74,7 +74,7 @@ size_t sml_transport_read(int fd, unsigned char *buffer, size_t max_len) {
 
 	// found start sequence
 
-	while (len < max_len) {
+	while ((len+8) < max_len) {
 		
 		sml_read(fd, &readfds, &(buf[len]), 4);
 			


### PR DESCRIPTION
Might fix some crashes (till now just guessing from code review. I don't know yet whether this is a root cause occurring yet.)