### PR TITLE
Fix build on non-Linux systems (e.g. Debian GNU/kFreeBSD)

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -3,7 +3,7 @@ CFLAGS += -I../sml/include/ -g -std=c99 -Wall -Wextra -pedantic
 OBJS = sml_server.o
 LIBSML = ../sml/lib/libsml.a
 
-ifeq ($(UNAME), Linux)
+ifneq ($(UNAME), Darwin)
 LIBS = -luuid
 endif
 

--- a/examples/sml_server.c
+++ b/examples/sml_server.c
@@ -33,7 +33,11 @@ int serial_port_open(const char* device) {
 	struct termios config;
 	memset(&config, 0, sizeof(config));
 
+#ifdef O_NONBLOCK
+	int fd = open(device, O_RDWR | O_NOCTTY | O_NONBLOCK);
+#else
 	int fd = open(device, O_RDWR | O_NOCTTY | O_NDELAY);
+#endif
 	if (fd < 0) {
 		fprintf(stderr,"error: open(%s): %s\n", device, strerror(errno));
 		return -1;

--- a/sml/Makefile
+++ b/sml/Makefile
@@ -4,7 +4,7 @@ CFLAGS += -I./include/ -fPIC -fno-stack-protector -g -std=c99 -Wall -Wextra -ped
 # Available Flags:
 # SML_NO_UUID_LIB - compile without uuid lib
 
-ifeq ($(UNAME), Linux)
+ifneq ($(UNAME), Darwin)
 LIBS=-luuid
 endif
 
@@ -46,10 +46,9 @@ OBJS = \
 	src/sml_get_profile_list_request.o \
 	src/sml_get_profile_list_response.o
 
-ifeq ($(UNAME), Linux)
+ifneq ($(UNAME), Darwin)
 libsml: $(DYN_LIB) $(ST_LIB) $(OBJ_LIB)
-endif
-ifeq ($(UNAME), Darwin)
+else
 libsml: $(ST_LIB) $(OBJ_LIB)
 endif
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@ UNAME := $(shell uname)
 CFLAGS += -I../sml/include/ -std=c99 -Wall -Wextra -pedantic
 LIBSML = ../sml/lib/libsml.a
 
-ifeq ($(UNAME), Linux)
+ifneq ($(UNAME), Darwin)
 LIBS = -luuid
 endif
 


### PR DESCRIPTION
Hi, 

I created a package of libsml for Debian which has been accepted in the package archive. Debian has some non-Linux architectures (GNU/kFreeBSD, Hurd) and a bug was reported about buildfailures: https://bugs.debian.org/873895

> 

> Builds of libsml for kfreebsd-{amd64,i386} (admittedly not release
> architectures) have been failing:
> 
>   make[2]: *** No rule to make target '../sml/lib/libsml.a', needed by 'sml_server'.  Stop.
> 
> The hurd-i386 build would have failed the same way if it hadn't first
> hit the O_NDELAY issue I just reported separately.

The full failed buildlog can be found [here](https://buildd.debian.org/status/fetch.php?pkg=libsml&arch=kfreebsd-amd64&ver=0.1.1%2Bgit20170608-1&stamp=1504185611&raw=0)

This pull-request adjusts the Makefile to only special-case Darwin instead of all non-Linux architectures when building libsml. This allows a successful build on kFreeBSD including the testsuite.

Additionally, on e.g. Hurd O_NDELAY isn't available and O_NONBLOCK should be used instead (on Linux both are the same).