### PR TITLE
print more details in example/sml_server

### DIFF
--- a/examples/sml_server.c
+++ b/examples/sml_server.c
@@ -103,12 +103,10 @@ void transport_receiver(unsigned char *buffer, size_t buffer_len) {
 						break;
 					}
 					printf("\n");
+					// flush the stdout puffer, that pipes work without waiting
+					fflush(stdout);
 				}
 			}
-
-			// free the malloc'd memory
-			sml_file_free(file);
-			exit(0); // processed first message - exit
 		}
 	}
 

--- a/examples/sml_server.c
+++ b/examples/sml_server.c
@@ -2,6 +2,9 @@
 // DAI-Labor, TU-Berlin
 //
 // This file is part of libSML.
+// Thanks to Thomas Binder and Axel (tuxedo) for providing code how to
+// print OBIS data (see transport_receiver()).
+// https://community.openhab.org/t/using-a-power-meter-sml-with-openhab/21923
 //
 // libSML is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -27,6 +30,7 @@
 
 #include <sml/sml_file.h>
 #include <sml/sml_transport.h>
+#include <sml/sml_value.h>
 
 int serial_port_open(const char* device) {
 	int bits;
@@ -35,7 +39,7 @@ int serial_port_open(const char* device) {
 
 	int fd = open(device, O_RDWR | O_NOCTTY | O_NDELAY);
 	if (fd < 0) {
-		printf("error: open(%s): %s\n", device, strerror(errno));
+		fprintf(stderr,"error: open(%s): %s\n", device, strerror(errno));
 		return -1;
 	}
 
@@ -62,15 +66,51 @@ int serial_port_open(const char* device) {
 }
 
 void transport_receiver(unsigned char *buffer, size_t buffer_len) {
+	int i;
 	// the buffer contains the whole message, with transport escape sequences.
 	// these escape sequences are stripped here.
 	sml_file *file = sml_file_parse(buffer + 8, buffer_len - 16);
 	// the sml file is parsed now
 
-	// read here some values ..
-
 	// this prints some information about the file
 	sml_file_print(file);
+
+	// read here some values ...
+	printf("OBIS data\n");
+	for (i = 0; i < file->messages_len; i++) {
+		sml_message *message = file->messages[i];
+		if (*message->message_body->tag == SML_MESSAGE_GET_LIST_RESPONSE) {
+			double value;
+			sml_list *entry;
+			sml_get_list_response *body;
+			body = (sml_get_list_response *) message->message_body->data;
+			for (entry = body->val_list; entry != NULL; entry = entry->next) {
+				value = sml_value_to_double(entry->value);
+				if (value != 0) {
+					int scaler = (entry->scaler) ? *entry->scaler : 1;
+					if (scaler == -1)
+						value *= 0.1;
+					printf("%d-%d:%d.%d.%d*%d#%.1f#",
+						entry->obj_name->str[0], entry->obj_name->str[1],
+						entry->obj_name->str[2], entry->obj_name->str[3],
+						entry->obj_name->str[4], entry->obj_name->str[5], value);
+					switch (*entry->unit) {
+					case 0x1B:
+						printf("W");
+						break;
+					case 0x1E:
+						printf("Wh");
+						break;
+					}
+					printf("\n");
+				}
+			}
+
+			// free the malloc'd memory
+			sml_file_free(file);
+			exit(0); // processed first message - exit
+		}
+	}
 
 	// free the malloc'd memory
 	sml_file_free(file);
@@ -79,7 +119,13 @@ void transport_receiver(unsigned char *buffer, size_t buffer_len) {
 int main(int argc, char **argv) {
 	// this example assumes that a EDL21 meter sending SML messages via a
 	// serial device. Adjust as needed.
-	char *device = "/dev/cu.usbserial";
+	if (argc != 2) {
+		printf("Usage: %s <device>\n", argv[0]);
+		printf("device - serial device of connected power meter e.g. /dev/cu.usbserial\n");
+		exit(-1); // exit here
+	}
+
+	char *device = argv[1];
 	int fd = serial_port_open(device);
 
 	if (fd > 0) {

--- a/sml/src/sml_value.c
+++ b/sml/src/sml_value.c
@@ -84,7 +84,7 @@ void sml_value_write(sml_value *value, sml_buffer *buf) {
 
 sml_value *sml_value_init() {
 	sml_value *value = (sml_value *) malloc(sizeof(sml_value));
-	memset(value, 0, sizeof(value));
+	memset(value, 0, sizeof(*value));
 
 	return value;
 }
@@ -118,7 +118,7 @@ double sml_value_to_double(sml_value *value) {
 		case 0x68: return *value->data.uint64; break;
 
 		default:
-			printf("error: unknown type in %s\n", __FUNCTION__);
+			fprintf(stderr, "error: unknown type in %s\n", __FUNCTION__);
 			return 0;
 	}
 }


### PR DESCRIPTION
I already created this pull request on dailab/libsml (see [#12](https://github.com/dailab/libsml/pull/12)) but @devZer0 told me that dailab/libsml is orphaned/dead end.

After having trouble getting detailed data out of my power meter I found some examples on other projects and merged this into a new version of `sml_server.c`. I think this helps others too.

Details:
    let the serial device set on command line
    print OBIS data

I also fixed a memset leak and sending errors to stderr instead of stdout in `sml/src/sml_value.c` which is fixed in this fork already. So you can ignore this.
