### PR TITLE
Fix creation of Debian packages

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -34,3 +34,5 @@ override_dh_installppp:
 override_dh_installudev:
 override_dh_perl:
 
+override_dh_auto_install:
+	dh_auto_install -- prefix=/usr

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -28,7 +28,8 @@ clean:
 	@rm -f sml_server
 
 install: sml_server
-	$(INSTALL) sml_server $(bindir)
+	$(INSTALL) -d $(DESTDIR)$(bindir)
+	$(INSTALL) sml_server $(DESTDIR)$(bindir)
 
 uninstall:
-	@rm -f $(bindir)/sml_server
+	@rm -f $(DESTDIR)$(bindir)/sml_server

--- a/sml/Makefile
+++ b/sml/Makefile
@@ -81,14 +81,16 @@ clean:
 	@rm -f $(DYN_LIB) $(OBJ_LIB) $(ST_LIB)
 
 install: $(DYN_LIB) $(ST_LIB)
-	$(INSTALL) $(DYN_LIB) $(ST_LIB) $(libdir)
+	install -d $(DESTDIR)$(libdir)
+	$(INSTALL) $(DYN_LIB) $(ST_LIB) $(DESTDIR)$(libdir)
 ifeq ($(UNAME), Darwin)
-	@cd $(libdir); ln -sf $(SONAME) $(NAME).dylib
+	@cd $(DESTDIR)$(libdir); ln -sf $(SONAME) $(NAME).dylib
 else
-	@cd $(libdir); ln -sf $(SONAME) $(NAME).so
+	@cd $(DESTDIR)$(libdir); ln -sf $(SONAME) $(NAME).so
 endif
-	cp -a $(INC_DIR)/* $(includedir)
+	install -d $(DESTDIR)$(includedir)
+	cp -a $(INC_DIR)/* $(DESTDIR)$(includedir)
 
 uninstall:
-	@rm -f $(libdir)/$(SONAME) $(libdir)/$(NAME).so $(libdir)/$(NAME).dylib $(libdir)/$(NAME).a
-	@rm -rf $(includedir)/sml
+	@rm -f $(DESTDIR)$(libdir)/$(SONAME) $(DESTDIR)$(libdir)/$(NAME).so $(DESTDIR)$(libdir)/$(NAME).dylib $(DESTDIR)$(libdir)/$(NAME).a
+	@rm -rf $(DESTDIR)$(includedir)/sml


### PR DESCRIPTION
With these three patches applied, `dpkg-buildpackage -uc -us -rfakeroot -b` works for me on a Debian stretch system.