### PR TITLE
sml_read(): exact read() error is returned in errno!

### DIFF
--- a/sml/src/sml_transport.c
+++ b/sml/src/sml_transport.c
@@ -25,7 +25,8 @@
 #include <sys/types.h>
 #include <string.h>
 #include <unistd.h>
-#include <errno.h>
+#include <errno.h>  // for errno
+#include <string.h> // for strerror_r
 
 #define MC_SML_BUFFER_LEN 8096
 
@@ -45,8 +46,8 @@ size_t sml_read(int fd, fd_set *set, unsigned char *buffer, size_t len) {
 
 			r = read(fd, &(buffer[tr]), len - tr);
 			if (r == 0) return 0; // EOF
-			if (r == EINTR || r == EAGAIN) continue; // should be ignored
 			if (r < 0) {
+				if (errno == EINTR || errno == EAGAIN) continue; // should be ignored
 				fprintf(stderr, "libsml: sml_read(): read error\n");
 				return 0;
 			}


### PR DESCRIPTION
fix bug in https://github.com/volkszaehler/libsml/pull/51

from `man read`:
```
RETURN VALUE
[...]
       On  error,  -1  is returned, and errno is set appropriately.
```