### PR TITLE
libsml: check for CRC errors on messages

### DIFF
--- a/sml/src/sml_file.c
+++ b/sml/src/sml_file.c
@@ -58,7 +58,8 @@ sml_file *sml_file_parse(unsigned char *buffer, size_t buffer_len) {
 			break;
 		}
 
-		sml_file_add_message(file, msg);
+		if (msg)
+			sml_file_add_message(file, msg);
 
 	}
 

--- a/test/src/sml_message_test.c
+++ b/test/src/sml_message_test.c
@@ -54,9 +54,17 @@ TEST(sml_message, parse) {
 	sml_message_free( msg );
 }
 
+TEST(sml_message, crc_error) {
+	hex2binary("7607003800003FB662006200736301017601010700380042153D0B06454D48010271533BCD010163820800", sml_buf_get_current_buf(buf));
+	//                                   ^ 1 bit corrupted here
+	sml_message *msg = sml_message_parse(buf);
+	TEST_ASSERT_NULL(msg);
+}
+
 TEST_GROUP_RUNNER(sml_message) {
 	RUN_TEST_CASE(sml_message, init);
 	RUN_TEST_CASE(sml_message, init_unique_transaction_id);
 	RUN_TEST_CASE(sml_message, parse);
+	RUN_TEST_CASE(sml_message, crc_error);
 }
 


### PR DESCRIPTION
Reject parsing messages with CRC errors to avoid reading
invalid data.

Add a test case for this as well.

Note that previously sml_message_parse() would only return
NULL for malformed messages (which could have happened via
corruption too), now it will also reject messages that have
a correct structure but whose checksum is incorrect.