### PR TITLE
Honor LDFLAGS variable

### DIFF
--- a/sml/Makefile
+++ b/sml/Makefile
@@ -16,6 +16,8 @@ else
 SONAME=$(NAME).so.$(SOVERSION)
 endif
 
+LDFLAGS += -Wl,-soname=$(SONAME) -shared
+
 LIB_DIR=./lib
 INC_DIR=./include
 OBJ_LIB=$(LIB_DIR)/$(NAME).o
@@ -66,7 +68,7 @@ $(DYN_LIB): $(OBJS)
 ifeq ($(UNAME), Darwin)
 	$(CC) $(LIBS) -dynamiclib -install_name $(SONAME) -o $@ $^
 else
-	$(LD) $(LIBS) -shared -soname $(SONAME) -o $@ $^
+	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 endif
 
 $(OBJ_LIB): $(OBJS)


### PR DESCRIPTION
The LDFLAGS variable is used to hold options for the linker, for example --as-needed  or some hardening flags. Previously, the values had no effect because the variable was never actually evaluated during the build. With this patch, linker options can be added as expected.