### PR TITLE
Improve constness in example sml_server

### DIFF
--- a/examples/sml_server.c
+++ b/examples/sml_server.c
@@ -135,7 +135,7 @@ void transport_receiver(unsigned char *buffer, size_t buffer_len) {
 						entry->obj_name->str[0], entry->obj_name->str[1],
 						entry->obj_name->str[2], entry->obj_name->str[3],
 						entry->obj_name->str[4], entry->obj_name->str[5], prec, value);
-					char *unit = NULL;
+					const char *unit = NULL;
 					if (entry->unit &&  // do not crash on null (unit is optional)
 						(unit = dlms_get_unit((unsigned char) *entry->unit)) != NULL)
 						printf("%s", unit);

--- a/examples/unit.h
+++ b/examples/unit.h
@@ -25,7 +25,7 @@
 
 typedef struct {
 	unsigned char code;
-	char *unit;
+	const char *unit;
 } dlms_unit_t;
 
 /**
@@ -103,7 +103,7 @@ dlms_unit_t dlms_units[] = {
 {0, ""}		// stop condition for iterator
 };
 	
-char * dlms_get_unit(unsigned char code) {
+const char * dlms_get_unit(unsigned char code) {
 	dlms_unit_t *it = dlms_units;
 	do { // linear search
 		if (it->code == code) {


### PR DESCRIPTION
Just some minor changes to use `const char*` instead of `char*`. Fixes some warnings during compilation.