### PR TITLE
Add PlatformIO library manifest

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,18 @@
+{
+    "name": "libSML",
+    "keywords": "sml, smartmeter, smart message language, smart meter",
+    "description": "Implementation in C of the Smart Message Language (SML) protocol",
+    "repository":
+    {
+      "type": "git",
+      "url": "https://github.com/volkszaehler/libsml"
+    },
+    "build": {
+        "includeDir": "sml/include",
+        "srcDir": "sml/src",
+        "flags": "-DSML_NO_UUID_LIB"
+    },
+    "version": "1.0",
+    "frameworks": "arduino",
+    "platforms": "*"
+  }


### PR DESCRIPTION
I'm currently in the process of refactoring my ESP8266 based SML reader (https://github.com/mruettgers/SMLReader) and I would like to integrate your sml library.
Therefore, and maybe for other PlatformIO or ESP/Arduino developers, it might be helpful to have the proper PlatformIO library manifest in place.

Thanks,
Michael