### PR TITLE
Fix crash accessing null crc

### DIFF
--- a/sml/src/sml_message.c
+++ b/sml/src/sml_message.c
@@ -68,7 +68,7 @@ sml_message *sml_message_parse(sml_buffer *buf) {
 	len = buf->cursor - msg_start;
 
 	msg->crc = sml_u16_parse(buf);
-	if (sml_buf_has_errors(buf))
+	if (sml_buf_has_errors(buf) || !(msg->crc))
 		goto error;
 
 	if (*msg->crc != sml_crc16_calculate(&(buf->buffer[msg_start]), len))

--- a/test/src/sml_file_test.c
+++ b/test/src/sml_file_test.c
@@ -41,8 +41,36 @@ TEST(sml_file, init) {
 	sml_file_free( file );
 }
 
+TEST(sml_file, parse_crash_report1) {
+	unsigned char buffer[388 - 16];
+
+	// this is from an error / crash report from vzlogger.
+	// with the following buffer (sadly only partial report)
+	// and bytes=388
+	// it reports an error type 0900 not yet implemented
+	// the fix was to check crc being not null
+
+	unsigned char buffer2[] =
+		"\033\033\033\033\001\001\001\001v\vESYA\037\350\005\265\203\021b\000b\000rc\001\001v\001"
+		"\004ESY\bESY+"
+		"\261\203\021\v\t\001ESY\021\003\246\037\350\001\001c\035R\000v\vESYA\037\350\005\265\203"
+		"\022b\000b\000rc\t\000\001ESY\021\003\246\037\350\a\001\000b\n\377\377rb\001e\001\347+"
+		"\261yw\a\201\201ǂ\003\377\001\001\001\001\004ESY\001w\a\001\000\000\000\t\377\001\001"
+		"\001"
+		"\001\v\t\001ESY\021\003\246\037\350\001w\a\001\000\001\b\000\377d\000\000\200\001b\036R"
+		"\374Y\000\000\000\tr\231\221\004\001w\a\001\000\020\a\000\377\001\001b\033R\376Y\000\000"
+		"\000\000\000\000i\231\001w\a\001\000$";
+	// sadly not... just 202 TEST_ASSERT_EQUAL(388, sizeof buffer2);
+	memcpy(buffer, buffer2, sizeof buffer2);
+	size_t bytes = 388;
+	// bytes and buffer like from sml_transport_read
+	sml_file *file = sml_file_parse(buffer + 8, bytes - 16);
+	TEST_ASSERT_NOT_NULL(file);
+	TEST_ASSERT_EQUAL(1, file->messages_len);
+	sml_file_free(file);
+}
 
 TEST_GROUP_RUNNER(sml_file) {
 	RUN_TEST_CASE(sml_file, init);
+	RUN_TEST_CASE(sml_file, parse_crash_report1);
 }
-


### PR DESCRIPTION
sml_u16_parse can return null.
So msg->crc can be null and needs to be verified before comparision.

Added a unit test for that problem as well.

Issue: vzlogger_crash_report #428