### PR TITLE
[test] fix building with -fno-common (gcc10 default),

### DIFF
--- a/test/src/sml_boolean_test.c
+++ b/test/src/sml_boolean_test.c
@@ -22,7 +22,7 @@
 
 TEST_GROUP(sml_boolean);
 
-sml_buffer *buf;
+static sml_buffer *buf;
 
 TEST_SETUP(sml_boolean) {
 	buf = sml_buffer_init(512);

--- a/test/src/sml_buffer_test.c
+++ b/test/src/sml_buffer_test.c
@@ -22,7 +22,7 @@
 TEST_GROUP(sml_buffer);
 
 int buffer_len = 512;
-sml_buffer *buf;
+static sml_buffer *buf;
 
 TEST_SETUP(sml_buffer) {
 	buf = sml_buffer_init(buffer_len);

--- a/test/src/sml_file_test.c
+++ b/test/src/sml_file_test.c
@@ -22,7 +22,7 @@
 
 TEST_GROUP(sml_file);
 
-sml_buffer *buf;
+static sml_buffer *buf;
 
 TEST_SETUP(sml_file) {
 	buf = sml_buffer_init(512);

--- a/test/src/sml_get_profile_pack_request_test.c
+++ b/test/src/sml_get_profile_pack_request_test.c
@@ -22,7 +22,7 @@
 
 TEST_GROUP(sml_get_profile_pack_request);
 
-sml_buffer *buf;
+static sml_buffer *buf;
 
 TEST_SETUP(sml_get_profile_pack_request) {
 	buf = sml_buffer_init(512);

--- a/test/src/sml_list_test.c
+++ b/test/src/sml_list_test.c
@@ -22,7 +22,7 @@
 
 TEST_GROUP(sml_list);
 
-sml_buffer *buf;
+static sml_buffer *buf;
 
 TEST_SETUP(sml_list) {
 	buf = sml_buffer_init(512);
@@ -100,7 +100,7 @@ TEST_GROUP_RUNNER(sml_list) {
 
 TEST_GROUP(sml_sequence);
 
-sml_buffer *buf;
+static sml_buffer *buf;
 
 TEST_SETUP(sml_sequence) {
 	buf = sml_buffer_init(512);

--- a/test/src/sml_message_test.c
+++ b/test/src/sml_message_test.c
@@ -22,7 +22,7 @@
 
 TEST_GROUP(sml_message);
 
-sml_buffer *buf;
+static sml_buffer *buf;
 
 TEST_SETUP(sml_message) {
 	buf = sml_buffer_init(512);

--- a/test/src/sml_number_test.c
+++ b/test/src/sml_number_test.c
@@ -23,7 +23,7 @@
 
 TEST_GROUP(sml_number);
 
-sml_buffer *buf;
+static sml_buffer *buf;
 
 TEST_SETUP(sml_number) {
 	buf = sml_buffer_init(512);

--- a/test/src/sml_octet_string_test.c
+++ b/test/src/sml_octet_string_test.c
@@ -22,7 +22,7 @@
 
 TEST_GROUP(sml_octet_string);
 
-sml_buffer *buf;
+static sml_buffer *buf;
 
 TEST_SETUP(sml_octet_string) {
 	buf = sml_buffer_init(512);

--- a/test/src/sml_open_request_test.c
+++ b/test/src/sml_open_request_test.c
@@ -22,7 +22,7 @@
 
 TEST_GROUP(sml_open_request);
 
-sml_buffer *buf;
+static sml_buffer *buf;
 
 TEST_SETUP(sml_open_request) {
 	buf = sml_buffer_init(512);

--- a/test/src/sml_status_test.c
+++ b/test/src/sml_status_test.c
@@ -22,7 +22,7 @@
 
 TEST_GROUP(sml_status);
 
-sml_buffer *buf;
+static sml_buffer *buf;
 
 TEST_SETUP(sml_status) {
 	buf = sml_buffer_init(512);

--- a/test/src/sml_time_test.c
+++ b/test/src/sml_time_test.c
@@ -22,7 +22,7 @@
 
 TEST_GROUP(sml_time);
 
-sml_buffer *buf;
+static sml_buffer *buf;
 
 TEST_SETUP(sml_time) {
 	buf = sml_buffer_init(512);

--- a/test/src/sml_tree_test.c
+++ b/test/src/sml_tree_test.c
@@ -23,7 +23,7 @@
 
 TEST_GROUP(sml_tree);
 
-sml_buffer *buf;
+static sml_buffer *buf;
 
 TEST_SETUP(sml_tree) {
 	buf = sml_buffer_init(512);

--- a/test/src/sml_value_test.c
+++ b/test/src/sml_value_test.c
@@ -22,7 +22,7 @@
 
 TEST_GROUP(sml_value);
 
-sml_buffer *buf;
+static sml_buffer *buf;
 
 TEST_SETUP(sml_value) {
 	buf = sml_buffer_init(512);


### PR DESCRIPTION
see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85678

fix https://github.com/volkszaehler/libsml/issues/87 https://github.com/volkszaehler/libsml/issues/90

this one gives each conflicting variable a local copy