### PR TITLE
fix: compiler warning about char -> unsigned char

### DIFF
--- a/sml/src/sml_octet_string.c
+++ b/sml/src/sml_octet_string.c
@@ -104,7 +104,7 @@ octet_string *sml_octet_string_generate_uuid() {
 	uuid_t uuid;
 	uuid_generate(uuid);
 #else
-	char uuid[16];
+	unsigned char uuid[16];
 
 // TODO add support for WIN32 systems
 #ifdef __linux__


### PR DESCRIPTION
Fixes a compiler warning when building without `libuuid`.

Without `libuuid` (`SML_NO_UUID_LIB` defined), the code takes the path via line 107:
https://github.com/volkszaehler/libsml/blob/7e7c5d46f82a8c8ce50c9be150da0c35bc0168cb/sml/src/sml_octet_string.c#L103-L107

Line 122 calls `sml_octet_string_init()` with `uuid` char array variable as the first parameter:
https://github.com/volkszaehler/libsml/blob/7e7c5d46f82a8c8ce50c9be150da0c35bc0168cb/sml/src/sml_octet_string.c#L122

`sml_octet_string_init()` expects unsigned char instead of char as the first argument:
https://github.com/volkszaehler/libsml/blob/7e7c5d46f82a8c8ce50c9be150da0c35bc0168cb/sml/src/sml_octet_string.c#L35