### PR TITLE
Expose the `workarounds` struct as part of public API

### DIFF
--- a/examples/sml_server.c
+++ b/examples/sml_server.c
@@ -41,6 +41,7 @@
 // globals
 int sflag = false; // flag to process only a single OBIS data stream
 int vflag = false; // verbose flag
+sml_workarounds workarounds = 0;
 
 
 int serial_port_open(const char* device) {
@@ -88,7 +89,7 @@ void transport_receiver(unsigned char *buffer, size_t buffer_len) {
 	int i;
 	// the buffer contains the whole message, with transport escape sequences.
 	// these escape sequences are stripped here.
-	sml_file *file = sml_file_parse(buffer + 8, buffer_len - 16);
+	sml_file *file = sml_file_parse(buffer + 8, buffer_len - 16, workarounds);
 	// the sml file is parsed now
 
 	// this prints some information about the file

--- a/examples/sml_server.c
+++ b/examples/sml_server.c
@@ -162,12 +162,16 @@ int main(int argc, char *argv[]) {
 	while ((c = getopt(argc, argv, "+hsv")) != -1) {
 		switch (c) {
 		case 'h':
-			printf("usage: %s [-h] [-s] [-v] device\n", argv[0]);
+			printf("usage: %s [-d] [-h] [-s] [-v] device\n", argv[0]);
 			printf("device - serial device of connected power meter e.g. /dev/cu.usbserial, or - for stdin\n");
+			printf("-d - Enable negative values workaround for certain DZG meters\n");
 			printf("-h - help\n");
 			printf("-s - process only one OBIS data stream (single)\n");
 			printf("-v - verbose\n");
 			exit(0); // exit here
+			break;
+		case 'd':
+			workarounds |= SML_WORKAROUND_DZG_NEGATIVE;
 			break;
 		case 's':
 			sflag = true;

--- a/sml/include/sml/sml_file.h
+++ b/sml/include/sml/sml_file.h
@@ -36,7 +36,8 @@ typedef struct {
 
 sml_file *sml_file_init();
 // parses a SML file.
-sml_file *sml_file_parse(unsigned char *buffer, size_t buffer_len);
+sml_file *sml_file_parse(unsigned char *buffer, size_t buffer_len,
+						 const sml_workarounds workarounds);
 void sml_file_add_message(sml_file *file, sml_message *message);
 void sml_file_write(sml_file *file);
 void sml_file_free(sml_file *file);

--- a/sml/src/sml_file.c
+++ b/sml/src/sml_file.c
@@ -27,11 +27,14 @@
 // EDL meter must provide at least 250 bytes as a receive buffer
 #define SML_FILE_BUFFER_LENGTH 512
 
-sml_file *sml_file_parse(unsigned char *buffer, size_t buffer_len) {
+sml_file *sml_file_parse(unsigned char *buffer, 
+						 size_t buffer_len,
+						 const sml_workarounds workarounds) {
 	sml_file *file = (sml_file *)malloc(sizeof(sml_file));
 	*file = (sml_file){.messages = NULL, .messages_len = 0, .buf = NULL};
 
 	sml_buffer *buf = sml_buffer_init(buffer_len);
+	buf->workarounds = workarounds;
 	memcpy(buf->buffer, buffer, buffer_len);
 	file->buf = buf;
 

--- a/sml/src/sml_shared.c
+++ b/sml/src/sml_shared.c
@@ -118,8 +118,12 @@ void sml_buf_update_bytes_read(sml_buffer *buf, int bytes) { buf->cursor += byte
 
 sml_buffer *sml_buffer_init(size_t length) {
 	sml_buffer *buf = (sml_buffer *)malloc(sizeof(sml_buffer));
-	*buf =
-		(sml_buffer){.buffer = NULL, .buffer_len = 0, .cursor = 0, .error = 0, .error_msg = NULL};
+	*buf = (sml_buffer){.buffer = NULL,
+						.buffer_len = 0,
+						.cursor = 0,
+						.error = 0,
+						.error_msg = NULL,
+						.workarounds = 0};
 	buf->buffer = (unsigned char *)malloc(length);
 	buf->buffer_len = length;
 	memset(buf->buffer, 0, buf->buffer_len);

--- a/test/src/sml_file_test.c
+++ b/test/src/sml_file_test.c
@@ -63,8 +63,9 @@ TEST(sml_file, parse_crash_report1) {
 	// sadly not... just 202 TEST_ASSERT_EQUAL(388, sizeof buffer2);
 	memcpy(buffer, buffer2, sizeof buffer2);
 	size_t bytes = 388;
+	sml_workarounds workarounds = 0;
 	// bytes and buffer like from sml_transport_read
-	sml_file *file = sml_file_parse(buffer + 8, bytes - 16);
+	sml_file *file = sml_file_parse(buffer + 8, bytes - 16, workarounds);
 	TEST_ASSERT_NOT_NULL(file);
 	TEST_ASSERT_EQUAL(1, file->messages_len);
 	sml_file_free(file);


### PR DESCRIPTION
This is supposed to become a sensible fix for #132. In that issue, it turned out that the workaround for broken negative values from DZG power meters cannot be applied automatically. For one model, DZG confirmed that the bug was fixed in devices with serial numbers starting with 6 (#106) - of a certain model, apparently. I have a different model, the DZG DWSB20.2TH with a serial number starting with 4. Mine does not exhibit the bug.

Since we only get the serial number and not the meter model via SML there is no way to reliably enable the fix automatically. Therefore I tried to expose the struct holding workaround flags as part of the public `libsml` API.

This also implies a corresponding PR for vzlogger. I have the code already and could push it anytime, however I may spare myself a rebase or two if we discuss this one first, maybe?

## Open Questions
- [ ] I'd like to mention the meter model the workaround is needed for in the explanatory code comment. Which one was that?