### PR TITLE
Added armel as release architecture

### DIFF
--- a/.github/workflows/debuild.yml
+++ b/.github/workflows/debuild.yml
@@ -68,7 +68,7 @@ jobs:
     needs: debuild
     strategy:
       matrix:
-        architecture: [armhf, arm64, amd64]
+        architecture: [armel, armhf, arm64, amd64]
         distribution: [trixie, bookworm, bullseye]
     runs-on: ubuntu-latest
     environment: main

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libsml (1.1.1) unstable; urgency=medium
+
+  * Added armel as release architecture 
+
+ -- Joachim Zobel <jz-2017@heute-morgen.de>  Tue, 31 Oct 2023 12:01:50 +0100
+
 libsml (1.1.0) unstable; urgency=medium
 
   * renamed hexdump to sml_hexdump 

--- a/library.json
+++ b/library.json
@@ -12,7 +12,7 @@
         "srcDir": "sml/src",
         "flags": "-DSML_NO_UUID_LIB"
     },
-    "version": "1.1.0",
+    "version": "1.1.1",
     "frameworks": "arduino",
     "platforms": "*"
   }

--- a/sml.pc
+++ b/sml.pc
@@ -5,7 +5,7 @@ includedir=${prefix}/include
 
 Name: libSML
 Description: Library for the Smart Messaging Language (SML)
-Version: 1.1.0
+Version: 1.1.1
 URL: http://github.com/volkszaehler/libsml
 Requires: uuid >= 2.16
 Libs: -L${libdir} -lsml


### PR DESCRIPTION
This is a very simple change. It has not been tested, but the worst that can happen is the loss of the beautiful version number 1.1.1 in case the build fails.