### PR TITLE
Raspbian

### DIFF
--- a/.github/workflows/debuild.yml
+++ b/.github/workflows/debuild.yml
@@ -70,18 +70,21 @@ jobs:
     needs: debuild
     strategy:
       matrix:
-        os: [debian]
-        architecture: [armel, armhf, arm64, amd64]
+        os: [debian, raspbian]
         distribution: [trixie, bookworm, bullseye]
-        include: 
-            - os: raspbian
-              architecture: armhf
-            - mirrorsite: http://ftp2.de.debian.org/debian/
-            - mirrorsite: http://mirror.netcologne.de/raspbian/raspbian/
-              os: raspbian
-            - keyring: debian-archive-keyring
-            - keyring: raspbian-archive-keyring
-              os: raspbian 
+        architecture: [armhf, arm64, amd64]
+        exclude:
+          - os: raspbian
+            architecture: arm64
+          - os: raspbian
+            architecture: amd64
+        include:
+          - mirrorsite: http://ftp2.de.debian.org/debian/
+          - mirrorsite: http://mirror.netcologne.de/raspbian/raspbian/
+            os: raspbian
+          - keyring: debian-archive-keyring
+          - keyring: raspbian-archive-keyring
+            os: raspbian
     runs-on: ubuntu-latest
     environment: main
     env:

--- a/.github/workflows/debuild.yml
+++ b/.github/workflows/debuild.yml
@@ -70,8 +70,18 @@ jobs:
     needs: debuild
     strategy:
       matrix:
+        os: [debian]
         architecture: [armel, armhf, arm64, amd64]
         distribution: [trixie, bookworm, bullseye]
+        include: 
+            - os: raspbian
+              architecture: armhf
+            - mirrorsite: http://ftp2.de.debian.org/debian/
+            - mirrorsite: http://mirror.netcologne.de/raspbian/raspbian/
+              os: raspbian
+            - keyring: debian-archive-keyring
+            - keyring: raspbian-archive-keyring
+              os: raspbian 
     runs-on: ubuntu-latest
     environment: main
     env:
@@ -80,10 +90,17 @@ jobs:
     steps:
       - name: update repo information
         run: sudo apt-get update
+      - name: install archive keyring
+        run: |
+          if [[ ${{ matrix.os }} == raspbian ]]; then
+            wget http://raspbian.raspberrypi.org/raspbian/pool/main/r/raspbian-archive-keyring/raspbian-archive-keyring_20120528.2_all.deb
+            sudo apt-get install ./raspbian-archive-keyring_20120528.2_all.deb    
+          else
+            sudo apt-get install debian-archive-keyring
+          fi
       - name: install pbuilder
         run: |
-          sudo apt-get install pbuilder qemu-user-static \
-            debian-archive-keyring pipx hub
+          sudo apt-get install pbuilder qemu-user-static pipx hub
         # Needed for the release download
       - uses: actions/checkout@v2
       - name: Set env
@@ -96,13 +113,13 @@ jobs:
           ls -l
       - name: configure pbuilder
         run: |
-          echo "MIRRORSITE=http://ftp2.de.debian.org/debian/
+          echo "MIRRORSITE=${{ matrix.mirrorsite }}
           HOOKDIR=$PBRT/hooks" | \
             sudo tee /root/.pbuilderrc
           sudo mkdir -p $PBRT/hooks
           echo "#!/bin/sh
 
-          apt-get -y install gnupg debian-archive-keyring
+          apt-get -y install gnupg ${{ matrix.keyring }}
           apt-key adv --keyserver pgp.mit.edu --recv-keys $SIGNING_KEY_ID" | \
             sudo tee $PBRT/hooks/G70Keys
         env:
@@ -116,8 +133,8 @@ jobs:
                  --debootstrap qemu-debootstrap \
                  --basetgz $PBRT/current.tgz \
                  --debootstrapopts \
-                     --keyring=/usr/share/keyrings/debian-archive-keyring.gpg
-      - name: pbuild ${{ matrix.architecture }} ${{ matrix.distribution }}
+                     --keyring=/usr/share/keyrings/${{ matrix.keyring }}.gpg
+      - name: pbuild ${{ matrix.os }} ${{ matrix.architecture }} ${{ matrix.distribution }}
         run: |
           VERSION="${GITHUB_REF##*/v}"
           sudo pbuilder build \
@@ -143,7 +160,7 @@ jobs:
             CHANGES_FILE="$PBRT/result/libsml_${VERSION}_${{ matrix.architecture }}.changes"
             for DEB in $(dcmd --deb $CHANGES_FILE); do
                 cloudsmith push deb \
-                    ${REPO}/debian/${{ matrix.distribution }} "$DEB"
+                    ${REPO}/${{ matrix.os }}/${{ matrix.distribution }} "$DEB"
             done
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}


### PR DESCRIPTION
This adds a build for Raspbian . It is done like the Debian builds, but uses the Raspbian repository.

The reason is that the RPi 1 uses an architecture that is named armhf without being compatible to the original architecture in Debian.
