### PR TITLE
Fixed lintian hardening info messages

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libsml (1.1.4) UNRELEASED; urgency=medium
+
+  * Removed -fno-stack-protector from CFLAGS
+  * Fixed all lintian hardening info messages
+
+ -- Joachim Zobel <jz-autosign@heute-morgen.de>  Thu, 23 May 2024 19:12:42 +0200
+
 libsml (1.1.3) unstable; urgency=medium
 
   * Added build for Raspbian.

--- a/debian/libsml1.symbols
+++ b/debian/libsml1.symbols
@@ -1,4 +1,5 @@
 libsml.so.1 libsml1 #MINVER#
+* Build-Depends-Package: libsml-dev
  c2ptoi@Base 0.1.1
  c2toi@Base 0.1.1
  ctoi@Base 0.1.1

--- a/debian/rules
+++ b/debian/rules
@@ -1,13 +1,13 @@
 #!/usr/bin/make -f
 
-# Build with all available hardening options
-export DEB_BUILD_MAINT_OPTIONS = hardening=+all
-
-VERSION=$(shell dpkg-parsechangelog --show-field Version 2>/dev/null | cut -f1 -d-)
+DEB_BUILD_MAINT_OPTIONS = hardening=+all
+DPKG_EXPORT_BUILDFLAGS = 1
+include /usr/share/dpkg/buildflags.mk
+include /usr/share/dpkg/pkg-info.mk
 
 execute_before_dh_auto_build:
-	sed -i 's#"version":.*#"version": "${VERSION}",#' library.json 
-	sed -i 's#Version:.*#Version: ${VERSION}#' sml.pc
+	sed -i 's#"version":.*#"version": "${DEB_VERSION_UPSTREAM}",#' library.json 
+	sed -i 's#Version:.*#Version: ${DEB_VERSION_UPSTREAM}#' sml.pc
 
 execute_after_dh_auto_build:
 	pandoc -o sml_server.1 -s -t man debian/sml_server.1.md

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -17,7 +17,7 @@ endif
 all: sml_server
 
 sml_server: $(OBJS) $(LIBSML)
-	$(CC) $(OBJS) $(LIBSML) $(LIBS) -o sml_server
+	$(CC) $(LDFLAGS) $(OBJS) $(LIBSML) $(LIBS) -o sml_server
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $^ -o $@

--- a/library.json
+++ b/library.json
@@ -12,7 +12,7 @@
         "srcDir": "sml/src",
         "flags": "-DSML_NO_UUID_LIB"
     },
-    "version": "1.1.2",
+    "version": "1.1.4",
     "frameworks": "arduino",
     "platforms": "*"
   }

--- a/sml.pc
+++ b/sml.pc
@@ -5,7 +5,7 @@ includedir=${prefix}/include
 
 Name: libSML
 Description: Library for the Smart Messaging Language (SML)
-Version: 1.1.2
+Version: 1.1.4
 URL: http://github.com/volkszaehler/libsml
 Requires: uuid >= 2.16
 Libs: -L${libdir} -lsml

--- a/sml/Makefile
+++ b/sml/Makefile
@@ -1,5 +1,5 @@
 UNAME := $(shell uname)
-CFLAGS += -I./include/ -fPIC -fno-stack-protector -g -std=c99 -Wall -Wextra -pedantic
+CFLAGS += -I./include/ -fPIC -g -std=c99 -Wall -Wextra -pedantic
 
 # Available Flags:
 # SML_NO_UUID_LIB - compile without uuid lib


### PR DESCRIPTION
I am unsure if the removal of -fno-stack-protector from CFLAGS has a negative impact.

This will probably not become a release, I just bumped the version to maintain the changelog.